### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v1.0.5
+- Bug fix for default conf file. Double quotes not needed and cause issue #11 
+- Updated Restore_Linux_Plex_Backup.sh to handle reading settings from conf file with spaces and no double quotes.
+
 v1.0.4
 - Bug fix for failing to start Plex Media Server. Issue #8
   - Fixed in Linux_Plex_Backup.sh

--- a/Linux_Plex_Backup.sh
+++ b/Linux_Plex_Backup.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2317,SC2181
 #--------------------------------------------------------------------------
 # Backup Linux Plex Database to tgz file in Backup folder.
-# v1.0.4  02-Jul-2024  007revad
+# v1.0.5  09-Nov-2024  007revad
 #
 #   MUST be run by a user in sudo, sudoers or wheel group, or as root
 #
@@ -18,7 +18,7 @@
 # Script verified at https://www.shellcheck.net/
 #--------------------------------------------------------------------------
 
-scriptver="v1.0.4"
+scriptver="v1.0.5"
 script=Linux_Plex_Backup
 
 
@@ -386,6 +386,7 @@ echo "=================================================" |& tee -a "${Log_File}"
 # Start Plex Media Server
 
 echo "Starting Plex..." |& tee -a "${Log_File}"
+#/usr/lib/plexmediaserver/Resources/start.sh
 systemctl start plexmediaserver
 
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,21 @@ If you run multiple backups on the same day the time will be included in the fil
 You need to set **backupDirectory=** near the top of the script (below the header). Set it to the location where you want the backup saved to. 
 
 ```YAML
-backupDirectory="/share/Backups/Plex_Backups"
+Backup_Directory=/share/Backups/Plex_Backups
+```
+or
+```YAML
+Backup_Directory=/share/folder with spaces/Plex_Backups
 ```
 
 The script gets the disto and hostname from the NAS to use logs and backup name.
-Set Name= to "distro", "hostname" or some nickname. If Name= is blank the Linux computer's hostname will be used.
+Set Name= to distro, hostname or you can set a 'nickname'. If Name= is blank the Linux computer's hostname will be used.
 
-The LogAll setting enables, or disables, logging every file that gets backed up. Set LogAll= to "yes" or "no". Blank is the same as no.
+The LogAll setting enables, or disables, logging every file that gets backed up. Set LogAll= to yes or no. Blank is the same as no.
 
 ```YAML
-Name="distro"
-LogAll="no"
+Name=distro
+LogAll=no
 ```
 
 ### Requirements

--- a/Restore_Linux_Plex_Backup.sh
+++ b/Restore_Linux_Plex_Backup.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2317,SC2181
 #--------------------------------------------------------------------------
 # Companion script for Linux Plex Backup script.
-# v1.0.4  02-Jul-2024  007revad
+# v1.0.5  09-Nov-2024  007revad
 #
 #   MUST be run by a user in sudo, sudoers or wheel group, or as root
 #
@@ -14,7 +14,7 @@
 # Script verified at https://www.shellcheck.net/
 #--------------------------------------------------------------------------
 
-scriptver="v1.0.4"
+scriptver="v1.0.5"
 script=Restore_Linux_Plex_Backup
 
 
@@ -23,8 +23,10 @@ Backup_Directory=""
 Name=""
 LogAll=""
 if [[ -f $(dirname -- "$0";)/backup_linux_plex.config ]];then
-    # shellcheck disable=SC1091
-    source "$(dirname -- "$0";)"/backup_linux_plex.config
+    # shellcheck disable=SC1090,SC1091
+    while read -r var; do
+        if [[ $var =~ ^[a-zA-Z0-9_]+=.* ]]; then export "$var"; fi
+    done < "$(dirname -- "$0";)"/backup_linux_plex.config
 else
     echo "backup_linux_plex.config file missing!"
     exit 1
@@ -346,6 +348,7 @@ echo "=================================================" |& tee -a "${Log_File}"
 # Start Plex Media Server
 
 echo "Starting Plex..." |& tee -a "${Log_File}"
+#/usr/lib/plexmediaserver/Resources/start.sh
 systemctl start plexmediaserver
 
 

--- a/backup_linux_plex.config
+++ b/backup_linux_plex.config
@@ -5,14 +5,14 @@
 #-------------------------------------------------------------------------
 
 # Set location to save tgz file to
-Backup_Directory="/share/Backups/Plex_Backup"
+Backup_Directory=/share/Backups/Plex_Backup
 
 # The script gets the distro and hostname for logging and the backup file name. 
-# Set Name= to "distro", "hostname" or some nickname.
-# If Name= is blank the Asustor's hostname will be used.
-Name="distro"
+# Set Name= to distro, hostname or set it to a 'nickname'.
+# If Name= is blank the computer's hostname will be used.
+Name=distro
 
 # Log all files backed up.
-# Set LogAll= to "yes" or "no". Blank is the same as no.
-LogAll="no"
+# Set LogAll= to yes or no. Blank is the same as no.
+LogAll=no
 


### PR DESCRIPTION
v1.0.5
- Bug fix for default conf file. Double quotes not needed and cause issue #11 
- Updated Restore_Linux_Plex_Backup.sh to handle reading settings from conf file with spaces and no double quotes.